### PR TITLE
Fix audit view performance (#576)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,10 +130,13 @@ an existing tornado install at a different major release than that in our
 
 .. code:: bash
 
-    virtualenv ~/merou-venv
-    ~/merou-venv/bin/pip install -r requirements.txt
-    ~/merou-venv/bin/pip install -r requirements-dev.txt
-    ~/merou-venv/bin/pytest
+    $ virtualenv ~/merou-venv -p /usr/bin/python3
+    $ source ~/merou-venv/bin/activate
+    (merou-venv) $ pip install -r requirements.txt
+    (merou-venv) $ pip install -r requirements-dev.txt
+    (merou-venv) $ pytest
+    (merou-venv) $ deactivate
+    $
 
 All Merou code is formatted with black, which is installed by the
 `requirements-dev.txt` requirements file for Python 3. After installation,

--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """ Command-line interface to various grouper administrative commands."""
 

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from grouper.audit import get_group_audit_members_infos
 from grouper.fe.handlers.template_variables import get_group_view_template_vars
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
@@ -26,5 +27,6 @@ class GroupView(GrouperHandler):
         self.render(
             "group.html",
             group=group,
+            audit_members_infos=get_group_audit_members_infos(self.session, group),
             **get_group_view_template_vars(self.session, self.current_user, group, self.graph)
         )

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
-                                help_for, account, service_account_panel %}
+                                help_for, account, service_account_panel, group_member_audit_status %}
 
 {% block subtitle %} group {{group.groupname}}{% endblock %}
 
@@ -207,19 +207,6 @@
 {% if group.audit and not group.audit.complete %}
 {# TODO(herb): audit db calls in this block #}
 
-{% macro audit_status(member) -%}
-    {% if member.member.name == current_user.name %}
-        <input type="hidden" name="audit_{{member.id}}" value="approved" />
-        approved
-    {% else %}
-        <select name="audit_{{member.id}}">
-            {% for status in statuses %}
-            <option {% if status == member.status %}selected{% endif %}>{{ status }}</option>
-            {% endfor %}
-        </select>
-    {% endif %}
-{% endmacro %}
-
 <div class="modal fade" id="auditModal" tabindex="-1" role="dialog"
       aria-labelledby="auditModal" aria-hidden="true" data-show="{{ "true" if group.audit and not group.audit.complete and current_user_role['is_owner'] else "false" }}">
     <div class="modal-dialog">
@@ -248,11 +235,11 @@
                         </tr>
                     </thead>
                     <tbody>
-                    {% for member in group.audit.my_members() %}
+                    {% for ami in audit_members_infos %}
                         <tr class="audit-member-row">
-                            <td class="audit-member-name">{{ account(member.member) }}</td>
-                            <td class="audit-member-role">{{ member.edge.role }}</td>
-                            <td class="audit-member-status">{{ audit_status(member) }}</td>
+                            <td class="audit-member-name">{{ account(ami.member_obj) }}</td>
+                            <td class="audit-member-role">{{ ROLES[ami.audit_member_role] }}</td>
+                            <td class="audit-member-status">{{ group_member_audit_status(current_user, ami.audit_member_obj, ami.member_obj, statuses) }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -320,6 +320,19 @@ enabled. Membership in this group is regularly reviewed.
 {% endif %}
 {%- endmacro %}
 
+{% macro group_member_audit_status(current_user, audit_member_obj, member_obj, statuses) -%}
+    {% if member_obj.name == current_user.name %}
+        <input type="hidden" name="audit_{{audit_member_obj.id}}" value="approved" />
+        approved
+    {% else %}
+        <select name="audit_{{audit_member_obj.id}}">
+            {% for status in statuses %}
+            <option {% if status == audit_member_obj.status %}selected{% endif %}>{{ status }}</option>
+            {% endfor %}
+        </select>
+    {% endif %}
+{% endmacro %}
+
 {% macro permission(perm) -%}
 <a class="permission-link" href="/permissions/{{perm.name or perm.permission}}">
     <i class="fa fa-key hidden-xs"></i>

--- a/grouper/fe/templates/service.html
+++ b/grouper/fe/templates/service.html
@@ -2,7 +2,7 @@
 
 {% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
                                 help_for, account, shell_panel, tokens_panel, passwords_panel,
-                                public_key_panel %}
+                                public_key_panel, group_member_audit_status %}
 
 {% from 'macros/ui.html' import public_key_modal with context %}
 
@@ -224,19 +224,6 @@
 {% if group.audit and not group.audit.complete %}
 {# TODO(herb): audit db calls in this block #}
 
-{% macro audit_status(member) -%}
-    {% if member.member.name == current_user.name %}
-        <input type="hidden" name="audit_{{member.id}}" value="approved" />
-        approved
-    {% else %}
-        <select name="audit_{{member.id}}">
-            {% for status in statuses %}
-            <option {% if status == member.status %}selected{% endif %}>{{ status }}</option>
-            {% endfor %}
-        </select>
-    {% endif %}
-{% endmacro %}
-
 <div class="modal fade" id="auditModal" tabindex="-1" role="dialog"
       aria-labelledby="auditModal" aria-hidden="true" data-show="{{ "true" if group.audit and not group.audit.complete and current_user_role['is_owner'] else "false" }}">
     <div class="modal-dialog">
@@ -265,12 +252,12 @@
                         </tr>
                     </thead>
                     <tbody>
-                    {% for member in group.audit.my_members() %}
+                    {% for ami in audit_members_infos %}
                         <tr>
-                            <td>{{ account(member.member) }}</td>
-                            <td>{{ member.edge.role }}</td>
+                            <td>{{ account(ami.member_obj) }}</td>
+                            <td>{{ ROLES[ami.audit_member_role] }}</td>
                             <td>
-                                {{ audit_status(member) }}
+                                {{ group_member_audit_status(current_user, ami.audit_member_obj, ami.member_obj, statuses) }}
                             </td>
                         </tr>
                     {% endfor %}

--- a/grouper/models/audit.py
+++ b/grouper/models/audit.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 
-from six import itervalues
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
-from grouper.models.audit_member import AuditMember
 from grouper.models.base.model_base import Model
 
 
@@ -32,47 +30,3 @@ class Audit(Model):
 
     # Tracks the last time we emailed the responsible parties of this audit
     last_reminder_at = Column(DateTime, nullable=True)
-
-    def my_members(self):
-        """Return all members of this audit
-
-        Only currently valid members (haven't since left the group and haven't joined since the
-        audit started).
-
-        Returns:
-            list(AuditMember): the members of the audit.
-        """
-
-        # Get all members of the audit. Note that this list might change since people can
-        # join or leave the group.
-        auditmembers = (
-            self.session.query(AuditMember).filter(AuditMember.audit_id == self.id).all()
-        )
-
-        auditmember_by_edge_id = {am.edge_id: am for am in auditmembers}
-
-        # Now get current members of the group. If someone has left the group, we don't include
-        # them in the audit anymore. If someone new joins (or rejoins) then we also don't want
-        # to audit them since they had to get approved into the group.
-        auditmember_name_pairs = []
-        for member in itervalues(self.group.my_members()):
-            if member.edge_id in auditmember_by_edge_id:
-                auditmember_name_pairs.append(
-                    (member.name, auditmember_by_edge_id[member.edge_id])
-                )
-
-        # Sort by name and return members
-        return [auditmember for _, auditmember in sorted(auditmember_name_pairs)]
-
-    @property
-    def completable(self):
-        """Whether or not this audit is completable
-
-        This is defined as "when all members have been assigned a non-pending status". I.e., at
-        that point, we can hit the Complete button which will perform any actions necessary to
-        the membership.
-
-        Returns:
-            bool: Whether or not this audit can be marked as completed.
-        """
-        return all([member.status != "pending" for member in self.my_members()])

--- a/grouper/models/audit_member.py
+++ b/grouper/models/audit_member.py
@@ -1,9 +1,7 @@
 from sqlalchemy import Column, Enum, ForeignKey, Integer
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.model_base import Model
-from grouper.models.user import User
 
 AUDIT_STATUS_CHOICES = {"pending", "approved", "remove"}
 
@@ -26,14 +24,3 @@ class AuditMember(Model):
     edge = relationship("GroupEdge", backref="audits", foreign_keys=[edge_id])
 
     status = Column(Enum(*AUDIT_STATUS_CHOICES), default="pending", nullable=False)
-
-    @hybrid_property
-    def member(self):
-        # TODO(cbguder): get around circular dependencies
-        from grouper.models.group import Group
-
-        if self.edge.member_type == 0:  # User
-            return User.get(self.session, pk=self.edge.member_pk)
-        elif self.edge.member_type == 1:  # Group
-            return Group.get(self.session, pk=self.edge.member_pk)
-        raise Exception("invalid member_type in AuditMember!")

--- a/grouper/models/group.py
+++ b/grouper/models/group.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 from collections import OrderedDict
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from six import iteritems
 from sqlalchemy import Boolean, Column, desc, Enum, Integer, Interval, or_, String, Text
@@ -233,7 +233,7 @@ class Group(Model, CommentObjectMixin):
         return od
 
     def my_members(self):
-        # type: () -> Mapping[Tuple[str, str], str]
+        # type: () -> Mapping[Tuple[str, str], Any]
         """Returns a dictionary from ("User"|"Group", "name") tuples to records."""
 
         parent = aliased(Group)

--- a/tests/audit_test.py
+++ b/tests/audit_test.py
@@ -1,5 +1,5 @@
-from collections import namedtuple
 from datetime import datetime, timedelta
+from typing import List, NamedTuple
 
 import pytest
 from mock import call, Mock, patch
@@ -11,6 +11,7 @@ from grouper.audit import (
     assert_controllers_are_auditors,
     get_auditors_group,
     get_audits,
+    get_group_audit_members_infos,
     GroupDoesNotHaveAuditPermission,
     user_is_auditor,
     UserNotAuditor,
@@ -170,15 +171,33 @@ def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):
     assert groupname in [x.group.name for x in open_audits], "group we expect also gets audit"
 
     # pull all the info we need to resolve audits, avoids detached sqlalchemy sessions
-    AuditMember = namedtuple("AuditMember", "am_id, edge_type, edge_id")
-    Audit = namedtuple("Audit", "audit_id, owner_name, group_name, audit_members")
+    # (DetachedInstanceError)
+    MyAuditMemberInfo = NamedTuple(
+        "MyAuditMemberInfo", [("am_id", int), ("edge_type", int), ("edge_id", int)]
+    )
+    Audit = NamedTuple(
+        "Audit",
+        [
+            ("audit_id", int),
+            ("owner_name", str),
+            ("group_name", str),
+            ("audit_members_infos", List[MyAuditMemberInfo]),
+        ],
+    )
     all_group_ids = [x.group.id for x in open_audits]
     open_audits = [
         Audit(
             x.id,
             next(iter(x.group.my_owners())),
             x.group.name,
-            [AuditMember(am.id, am.edge.member_type, am.edge_id) for am in x.my_members()],
+            [
+                MyAuditMemberInfo(
+                    ami.audit_member_obj.id,
+                    ami.audit_member_obj.edge.member_type,
+                    ami.audit_member_obj.edge_id,
+                )
+                for ami in get_group_audit_members_infos(session, x.group)
+            ],
         )
         for x in open_audits
     ]
@@ -192,7 +211,7 @@ def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):
 
         # blanket approval
         body = urlencode(
-            {"audit_{}".format(am.am_id): "approved" for am in one_audit.audit_members}
+            {"audit_{}".format(ami.am_id): "approved" for ami in one_audit.audit_members_infos}
         )
 
         resp = yield http_client.fetch(
@@ -207,13 +226,13 @@ def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):
     one_audit.id
 
     body_dict = {}
-    for am in one_audit.my_members():
-        if gary_id == am.member.id:
+    for ami in get_group_audit_members_infos(session, one_audit.group):
+        if gary_id == ami.member_obj.id:
             # deny
-            body_dict["audit_{}".format(am.id)] = "remove"
+            body_dict["audit_{}".format(ami.audit_member_obj.id)] = "remove"
         else:
             # approve
-            body_dict["audit_{}".format(am.id)] = "approved"
+            body_dict["audit_{}".format(ami.audit_member_obj.id)] = "approved"
 
     owner_name = next(iter(one_audit.group.my_owners()))
     fe_url = url(base_url, "/audits/{}/complete".format(one_audit.id))

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import optparse
 import subprocess


### PR DESCRIPTION
Improve performance of viewing audit information about a group

Introduce `get_group_audit_members_infos()` in to `grouper/audit.py` that uses a small number of
queries to collect all the audit information about a group's members that the frontend needs to
display the audit modal. Avoid using `AuditMember`'s `member()` property because displaying a large group would require 2 queries per member of the group; in fact, remove that business logic function altogether (as well as `my_members()`) from the AuditMember model.

Also, use a dedicated query to check whether a group still has some memberships pending audit, instead of retrieving all the members and then checking their audit statuses.